### PR TITLE
Fix PHP Fatal error Access level to PrivateMessageRecorderCapabilities::record() must be public

### DIFF
--- a/src/MPWAR/Module/Economy/Domain/Account.php
+++ b/src/MPWAR/Module/Economy/Domain/Account.php
@@ -4,10 +4,10 @@ namespace MPWAR\Module\Economy\Domain;
 
 use DateTimeImmutable;
 use MPWAR\Module\Economy\Contract\DomainEvent\AccountOpened;
+use SimpleBus\Message\Recorder\ContainsRecordedMessages;
 use SimpleBus\Message\Recorder\PrivateMessageRecorderCapabilities;
-use SimpleBus\Message\Recorder\RecordsMessages;
 
-final class Account implements RecordsMessages
+final class Account implements ContainsRecordedMessages
 {
     private $owner;
     private $balance;

--- a/src/MPWAR/Module/Player/Domain/Player.php
+++ b/src/MPWAR/Module/Player/Domain/Player.php
@@ -4,10 +4,10 @@ namespace MPWAR\Module\Player\Domain;
 
 use DateTimeImmutable;
 use MPWAR\Module\Player\Contract\DomainEvent\PlayerRegistered;
+use SimpleBus\Message\Recorder\ContainsRecordedMessages;
 use SimpleBus\Message\Recorder\PrivateMessageRecorderCapabilities;
-use SimpleBus\Message\Recorder\RecordsMessages;
 
-final class Player implements RecordsMessages
+final class Player implements ContainsRecordedMessages
 {
     private $id;
     private $name;


### PR DESCRIPTION
Fix PHP Fatal error: Access level to SimpleBus\Message\Recorder\PrivateMessageRecorderCapabilities::record() must be public (as in class SimpleBus\Message\Recorder\RecordsMessages) in Module/Player/Domain/Player.php on line 48 and in Module/Economy/Domain/Account.php on line 41

Those classes (Account and Player) must implement ContainsRecordedMessages instead of RecordsMessages since its messages are private and not public.
